### PR TITLE
Fix build with build gradle plugin id

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -40,7 +40,7 @@ Write your build.gradle(.kts) as follows:
             }
             
             dependencies {
-                implementation("org.seasar.doma:doma-core:3.3.0")
+                implementation("org.seasar.doma:doma-core:3.4.0")
                 annotationProcessor("org.seasar.doma:doma-processor:3.3.0")
             }
 
@@ -53,7 +53,7 @@ Write your build.gradle(.kts) as follows:
             }
             
             dependencies {
-                implementation 'org.seasar.doma:doma-core:3.3.0'
+                implementation 'org.seasar.doma:doma-core:3.4.0'
                 annotationProcessor 'org.seasar.doma:doma-processor:3.3.0'
             }
 

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -36,7 +36,7 @@ Write your build.gradle(.kts) as follows:
         .. code-block:: kotlin
 
             plugins {
-                id("org.seasar.doma.compile") version "3.0.1"
+                id("org.domaframework.doma.compile") version "3.0.1"
             }
             
             dependencies {
@@ -49,7 +49,7 @@ Write your build.gradle(.kts) as follows:
         .. code-block:: groovy
 
             plugins {
-                id 'org.seasar.doma.compile' version '3.0.1'
+                id 'org.domaframework.doma.compile' version '3.0.1'
             }
             
             dependencies {
@@ -57,7 +57,7 @@ Write your build.gradle(.kts) as follows:
                 annotationProcessor 'org.seasar.doma:doma-processor:3.3.0'
             }
 
-To simplify your build.script(.kts), we recommend that you use the `org.seasar.doma.compile`_ plugin.
+To simplify your build.script(.kts), we recommend that you use the `org.domaframework.doma.compile`_ plugin.
 
 See build.gradle.kts in the `getting-started`_ repository as an example.
 
@@ -163,6 +163,6 @@ Import your project as a Maven project.
 Build and run using Maven.
 
 
-.. _org.seasar.doma.compile: https://github.com/domaframework/doma-compile-plugin
+.. _org.domaframework.doma.compile: https://github.com/domaframework/doma-compile-plugin
 .. _com.diffplug.eclipse.apt: https://plugins.gradle.org/plugin/com.diffplug.eclipse.apt
 .. _getting-started: https://github.com/domaframework/getting-started

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -41,7 +41,7 @@ Write your build.gradle(.kts) as follows:
             
             dependencies {
                 implementation("org.seasar.doma:doma-core:3.4.0")
-                annotationProcessor("org.seasar.doma:doma-processor:3.3.0")
+                annotationProcessor("org.seasar.doma:doma-processor:3.4.0")
             }
 
     .. tab:: Groovy

--- a/docs/kotlin-support.rst
+++ b/docs/kotlin-support.rst
@@ -130,7 +130,7 @@ You can write build.gradle.kts as follows:
 .. code-block:: kotlin
 
     dependencies {
-        implementation("org.seasar.doma:doma-kotlin:3.3.0")
+        implementation("org.seasar.doma:doma-kotlin:3.4.0")
     }
 
 Code Generation
@@ -151,8 +151,8 @@ For example, you can write build.gradle.kts as follows:
 .. code-block:: kotlin
 
     dependencies {
-        kapt("org.seasar.doma:doma-processor:3.3.0")
-        implementation("org.seasar.doma:doma-kotlin:3.3.0")
+        kapt("org.seasar.doma:doma-processor:3.4.0")
+        implementation("org.seasar.doma:doma-kotlin:3.4.0")
     }
 
 To simplify your build script, we recommend you use

--- a/docs/locale/ja/LC_MESSAGES/build.po
+++ b/docs/locale/ja/LC_MESSAGES/build.po
@@ -77,8 +77,8 @@ msgid "Groovy"
 msgstr ""
 
 #: ../../build.rst:60
-msgid "To simplify your build.script(.kts), we recommend that you use the `org.seasar.doma.compile`_ plugin."
-msgstr "build.script(.kts) を簡素化するには、`org.seasar.doma.compile`_ プラグインを使用することをお勧めします。"
+msgid "To simplify your build.script(.kts), we recommend that you use the `org.domaframework.doma.compile`_ plugin."
+msgstr "build.script(.kts) を簡素化するには、`org.domaframework.doma.compile`_ プラグインを使用することをお勧めします。"
 
 #: ../../build.rst:62
 #: ../../build.rst:122

--- a/docs/quarkus-support.rst
+++ b/docs/quarkus-support.rst
@@ -25,7 +25,7 @@ Gradle
 
     dependencies {
         annotationProcessor("org.seasar.doma:doma-processor:3.3.0")
-        implementation("org.seasar.doma:doma-core:3.3.0")
+        implementation("org.seasar.doma:doma-core:3.4.0")
         implementation("io.quarkiverse.doma:quarkus-doma:0.0.13")
     }
 

--- a/docs/quarkus-support.rst
+++ b/docs/quarkus-support.rst
@@ -24,7 +24,7 @@ Gradle
 .. code-block:: kotlin
 
     dependencies {
-        annotationProcessor("org.seasar.doma:doma-processor:3.3.0")
+        annotationProcessor("org.seasar.doma:doma-processor:3.4.0")
         implementation("org.seasar.doma:doma-core:3.4.0")
         implementation("io.quarkiverse.doma:quarkus-doma:0.0.13")
     }

--- a/docs/slf4j-support.rst
+++ b/docs/slf4j-support.rst
@@ -19,7 +19,7 @@ Doma provides the doma-slf4j artifact to adapt SLF4J.
 .. code-block:: xml
 
     dependencies {
-        implementation("org.seasar.doma:doma-slf4j:3.3.0")
+        implementation("org.seasar.doma:doma-slf4j:3.4.0")
         // Use an arbitrary SLF4J binding
         runtimeOnly("ch.qos.logback:logback-classic:1.5.7")
     }

--- a/docs/sql.rst
+++ b/docs/sql.rst
@@ -856,7 +856,7 @@ Gradle
 .. code-block:: xml
 
     dependencies {
-        implementation("org.seasar.doma:doma-template:3.3.0")
+        implementation("org.seasar.doma:doma-template:3.4.0")
     }
 
 Usage


### PR DESCRIPTION
`Plugin [id: 'org.seasar.doma.compile', version: '3.0.1'] was not found in any of the following` 
というエラーが出るため。

https://github.com/domaframework/doma-compile-plugin の [Gradle Plugin Portal](https://plugins.gradle.org/plugin/org.domaframework.doma.compile) では下記のように記載。

```
plugins {
  id("org.domaframework.doma.compile") version "3.0.1"
}
```

`The import org.seasar.doma.Association cannot be resolvedJava(268435846)` というエラーが出るため、
`3.4.0` に修正。
(すいません、こちらはPR分けるべきだったかもです！)