### PR TITLE
Add migration notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Doma Documentation
 
+> [!IMPORTANT]
+> **This documentation has been migrated to the main Doma repository.**
+> 
+> Please visit https://github.com/domaframework/doma/ for the latest documentation.
+> 
+> This repository is now archived and no longer maintained.
+
+---
+
 This repository manages the English version of the [Doma](https://github.com/domaframework/doma) documentation.
 Localization into Japanese is managed manually.
 


### PR DESCRIPTION
## Summary
- Added a prominent notice at the top of README.md indicating documentation migration
- Used GitHub's alert syntax (`[\!IMPORTANT]`) for better visibility
- Clearly states that the repository is archived and no longer maintained

## Migration Notice
The notice directs users to the new location at https://github.com/domaframework/doma/ where the documentation has been migrated.

🤖 Generated with [Claude Code](https://claude.ai/code)